### PR TITLE
One react-accounts-ui escaped the renaming!

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This is the default setting for **passwordSignupFields** in the [configuration](
 ```javascript
 
 import React from 'react';
-import { Accounts } from 'meteor/std:react-accounts-ui';
+import { Accounts } from 'meteor/std:accounts-ui';
 
 Accounts.ui.config({
   passwordSignupFields: 'NO_PASSWORD',


### PR DESCRIPTION
Well, just a `react-accounts-ui` which was still there!

By the way, awesome package @timbrandin ! :rocket: 