### PR TITLE
Reflect props changes in state of LoginForm component.

### DIFF
--- a/imports/ui/components/LoginForm.jsx
+++ b/imports/ui/components/LoginForm.jsx
@@ -64,6 +64,14 @@ export class LoginForm extends Tracker.Component {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.formState != this.state.formState) {
+      this.setState({
+        formState: nextProps.formState
+      }); 
+    }
+  }
+
   validateUsername( username ) {
     if ( username ) {
       return true;


### PR DESCRIPTION
Fixes issue #39.

A cleaner way to do this, would probably be to use the components props as [a single source of truth](https://facebook.github.io/react/docs/interactivity-and-dynamic-uis.html#what-shouldnt-go-in-state), but this fixes the issue for now.

What do you think?