### PR TITLE
Create new form state for Enroll Account

### DIFF
--- a/imports/accounts_ui.js
+++ b/imports/accounts_ui.js
@@ -28,7 +28,10 @@ Accounts.ui._options = {
   onResetPasswordHook: () => redirect(`${Accounts.ui._options.loginPath}`),
   onVerifyEmailHook: () => redirect(`${Accounts.ui._options.profilePath}`),
   onSignedInHook: () => null,
-  onSignedOutHook: () => null
+  onSignedOutHook: () => null,
+  onPostResetPasswordHook: () => null,
+  onPostEnrollAccountHook: () => null
+
 };
 
 /**
@@ -62,7 +65,9 @@ Accounts.ui.config = function(options) {
     'onResetPasswordHook',
     'onVerifyEmailHook',
     'onSignedInHook',
-    'onSignedOutHook'
+    'onSignedOutHook',
+    'onPostResetPasswordHook',
+    'onPostEnrollAccountHook'
   ];
 
   _.each(_.keys(options), function (key) {
@@ -189,7 +194,9 @@ Accounts.ui.config = function(options) {
       'onResetPasswordHook',
       'onVerifyEmailHook',
       'onSignedInHook',
-      'onSignedOutHook']) {
+      'onSignedOutHook',
+      'onPostResetPasswordHook',
+      'onPostEnrollAccountHook' ]) {
     if (options[hook]) {
       if (typeof options[hook] == 'function') {
         Accounts.ui._options[hook] = options[hook];

--- a/imports/helpers.js
+++ b/imports/helpers.js
@@ -4,7 +4,8 @@ export const STATES = {
   SIGN_UP: Symbol('SIGN_UP'),
   PROFILE: Symbol('PROFILE'),
   PASSWORD_CHANGE: Symbol('PASSWORD_CHANGE'),
-  PASSWORD_RESET: Symbol('PASSWORD_RESET')
+  PASSWORD_RESET: Symbol('PASSWORD_RESET'),
+  ENROLL_ACCOUNT: Symbol('ENROLL_ACCOUNT')
 };
 
 export function getLoginServices() {

--- a/imports/ui/components/LoginForm.jsx
+++ b/imports/ui/components/LoginForm.jsx
@@ -53,6 +53,12 @@ export class LoginForm extends Tracker.Component {
     let changeState = Session.get(KEY_PREFIX + 'state');
     switch (changeState) {
       case 'enrollAccountToken':
+        this.setState({
+          formState: STATES.ENROLL_ACCOUNT
+        });
+        Session.set(KEY_PREFIX + 'state', null);
+        break;
+
       case 'resetPasswordToken':
         this.setState({
           formState: STATES.PASSWORD_CHANGE
@@ -165,6 +171,17 @@ export class LoginForm extends Tracker.Component {
     };
   }
 
+  getSetPasswordField() {
+    return {
+      id: 'newPassword',
+      hint: T9n.get('enterPassword'),
+      label: T9n.get('choosePassword'),
+      type: 'password',
+      required: true,
+      onChange: this.handleChange.bind(this, 'newPassword')
+    };
+  }
+
   handleChange(field, evt) {
     let value = evt.target.value;
     switch (field) {
@@ -251,12 +268,16 @@ export class LoginForm extends Tracker.Component {
     }
 
     if (this.showPasswordChangeForm()) {
-      if (Meteor.isClient && !Accounts._loginButtonsSession.get('resetPasswordToken')
-        && !Accounts._loginButtonsSession.get('enrollAccountToken')) {
+      if (Meteor.isClient && !Accounts._loginButtonsSession.get('resetPasswordToken')) {
         loginFields.push(this.getPasswordField());
       }
       loginFields.push(this.getNewPasswordField());
     }
+
+    if (this.showEnrollAccountForm()) {
+      loginFields.push(this.getSetPasswordField());
+    }
+
 
     return _.indexBy(loginFields, 'id');
   }
@@ -351,10 +372,10 @@ export class LoginForm extends Tracker.Component {
       });
     }
 
-    if (this.showPasswordChangeForm()) {
+    if (this.showPasswordChangeForm() || this.showEnrollAccountForm()) {
       loginButtons.push({
         id: 'changePassword',
-        label: T9n.get('changePassword'),
+        label: (this.showPasswordChangeForm() ? T9n.get('changePassword') : T9n.get('setPassword')),
         type: 'submit',
         disabled: waiting,
         onClick: this.passwordChange.bind(this)
@@ -389,6 +410,11 @@ export class LoginForm extends Tracker.Component {
   showPasswordChangeForm() {
     return(Package['accounts-password']
       && this.state.formState == STATES.PASSWORD_CHANGE);
+  }
+
+  showEnrollAccountForm() {
+    return(Package['accounts-password']
+      && this.state.formState == STATES.ENROLL_ACCOUNT);
   }
 
   showCreateAccountLink() {

--- a/imports/ui/components/LoginForm.jsx
+++ b/imports/ui/components/LoginForm.jsx
@@ -35,7 +35,9 @@ export class LoginForm extends Tracker.Component {
       onSignedInHook: props.onSignedInHook || Accounts.ui._options.onSignedInHook,
       onSignedOutHook: props.onSignedOutHook || Accounts.ui._options.onSignedOutHook,
       onPreSignUpHook: props.onPreSignUpHook || Accounts.ui._options.onPreSignUpHook,
-      onPostSignUpHook: props.onPostSignUpHook || Accounts.ui._options.onPostSignUpHook
+      onPostSignUpHook: props.onPostSignUpHook || Accounts.ui._options.onPostSignUpHook,
+      onPostResetPasswordHook: props.onPostResetPasswordHook || Accounts.ui._options.onPostResetPasswordHook,
+      onPostEnrollAccountHook: props.onPostEnrollAccountHook || Accounts.ui._options.onPostEnrollAccountHook
     };
 
     // Listen for the user to login/logout.
@@ -765,8 +767,18 @@ export class LoginForm extends Tracker.Component {
         else {
           this.showMessage(T9n.get('info.passwordChanged'), 'success', 5000);
           this.setState({ formState: STATES.PROFILE });
+
+          //Determin what hook to call after password set / reset
+          let hookFunction = () => null;
+          if (Accounts._loginButtonsSession.get('resetPasswordToken')) {
+            hookFunction = this.state.onPostResetPasswordHook;
+          } else if (Accounts._loginButtonsSession.get('enrollAccountToken')){
+            hookFunction = this.state.onPostEnrollAccountHook;
+          }
+
           Accounts._loginButtonsSession.set('resetPasswordToken', null);
           Accounts._loginButtonsSession.set('enrollAccountToken', null);
+          hookFunction();
         }
       });
     }


### PR DESCRIPTION
Enroll account now has its own form state to allow more control over form labels and buttons, prompting user to set a password instead of changing a password.