### PR TITLE
Fix issue, when message is object in Accounts.ui.FormMessage

### DIFF
--- a/imports/ui/components/FormMessage.jsx
+++ b/imports/ui/components/FormMessage.jsx
@@ -4,6 +4,7 @@ import { Accounts } from 'meteor/accounts-base';
 export class FormMessage extends React.Component {
   render () {
     let { message, type, className = "message", style = {} } = this.props;
+    message = _.isObject(message) ? message.message : message; // If message is object, then try to get message from it
     return message ? (
       <div style={ style } 
            className={[ className, type ].join(' ')}>{ message }</div>


### PR DESCRIPTION
I don`t now, what happend and in witch version of meteor. But I`ve had troubles with 
meteor/std:accounts-ui
and
zetoff:accounts-material-ui

It`s fast simple fix, checked on meteor 1.4.1 and 1.4.2
