### PR TITLE
Quick fix to redirect login/logout

### DIFF
--- a/imports/accounts_ui.js
+++ b/imports/accounts_ui.js
@@ -27,8 +27,8 @@ Accounts.ui._options = {
   onEnrollAccountHook: () => redirect(`${Accounts.ui._options.loginPath}`),
   onResetPasswordHook: () => redirect(`${Accounts.ui._options.loginPath}`),
   onVerifyEmailHook: () => redirect(`${Accounts.ui._options.profilePath}`),
-  onSignedInHook: () => null,
-  onSignedOutHook: () => null
+  onSignedInHook: () => redirect(`${Accounts.ui._options.homeRoutePath}`),
+  onSignedOutHook: () => redirect(`${Accounts.ui._options.homeRoutePath}`)
 };
 
 /**


### PR DESCRIPTION
Quick fix to redirect login/logout to homeRoutePath when it is not set?
not sure if this is the right way to do it but when I use is logged in/out expected behavior is to send them to the frontpage instead of sting on the same page!