### PR TITLE
Better support for Server-Side Rendering & client-only code in React client-only lifecycle hook

### DIFF
--- a/imports/ui/components/LoginForm.jsx
+++ b/imports/ui/components/LoginForm.jsx
@@ -45,15 +45,6 @@ export class LoginForm extends Tracker.Component {
       onPreSignUpHook: props.onPreSignUpHook || Accounts.ui._options.onPreSignUpHook,
       onPostSignUpHook: props.onPostSignUpHook || Accounts.ui._options.onPostSignUpHook,
     };
-
-    // Listen for the user to login/logout.
-    this.autorun(() => {
-      // Add the services list to the user.
-      this.subscribe('servicesList');
-      this.setState({
-        user: Accounts.user()
-      });
-    });
   }
 
   componentDidMount() {
@@ -85,6 +76,17 @@ export class LoginForm extends Tracker.Component {
     this.setState(prevState => ({
       ...this.getDefaultFieldValues(),
     }));
+    
+    // Listen for the user to login/logout.
+    this.autorun(() => {
+      
+      // Add the services list to the user.
+      this.subscribe('servicesList');
+      this.setState({
+        user: Accounts.user()
+      });
+      
+    });
   }
 
   componentWillReceiveProps(nextProps, nextContext) {

--- a/imports/ui/components/LoginForm.jsx
+++ b/imports/ui/components/LoginForm.jsx
@@ -57,34 +57,34 @@ export class LoginForm extends Tracker.Component {
   }
 
   componentDidMount() {
-    this.setState({ waiting: false, ready: true });
+    this.setState(prevState => ({ waiting: false, ready: true }));
     let changeState = Session.get(KEY_PREFIX + 'state');
     switch (changeState) {
       case 'enrollAccountToken':
-        this.setState({
+        this.setState(prevState => ({
           formState: STATES.ENROLL_ACCOUNT
-        });
+        }));
         Session.set(KEY_PREFIX + 'state', null);
         break;
       case 'resetPasswordToken':
-        this.setState({
+        this.setState(prevState => ({
           formState: STATES.PASSWORD_CHANGE
-        });
+        }));
         Session.set(KEY_PREFIX + 'state', null);
         break;
 
       case 'justVerifiedEmail':
-        this.setState({
+        this.setState(prevState => ({
           formState: STATES.PROFILE
-        });
+        }));
         Session.set(KEY_PREFIX + 'state', null);
         break;
     }
     
     // Add default field values once the form did mount on the client
-    this.setState({
+    this.setState(prevState => ({
       ...this.getDefaultFieldValues(),
-    });
+    }));
   }
 
   componentWillReceiveProps(nextProps, nextContext) {
@@ -995,6 +995,6 @@ export class LoginForm extends Tracker.Component {
       />
     );
   }
-};
+}
 
 Accounts.ui.LoginForm = LoginForm;

--- a/imports/ui/components/LoginForm.jsx
+++ b/imports/ui/components/LoginForm.jsx
@@ -44,8 +44,6 @@ export class LoginForm extends Tracker.Component {
       onSignedOutHook: props.onSignedOutHook || Accounts.ui._options.onSignedOutHook,
       onPreSignUpHook: props.onPreSignUpHook || Accounts.ui._options.onPreSignUpHook,
       onPostSignUpHook: props.onPostSignUpHook || Accounts.ui._options.onPostSignUpHook,
-      // Add default field values.
-      ...this.getDefaultFieldValues(),
     };
 
     // Listen for the user to login/logout.
@@ -82,6 +80,11 @@ export class LoginForm extends Tracker.Component {
         Session.set(KEY_PREFIX + 'state', null);
         break;
     }
+    
+    // Add default field values once the form did mount on the client
+    this.setState({
+      ...this.getDefaultFieldValues(),
+    });
   }
 
   componentWillReceiveProps(nextProps, nextContext) {


### PR DESCRIPTION
Hey @timbrandin! 

First of all, thanks: that's great to see this package getting better and better!! I love the latest updates! 👍


### Problem 
I'm using it on a server-side rendered app, and I noticed that if the form is on the page on initial render, there is an issue between its initial state on the server & the client, causing a performance loss:

![screenshot react markup injection trouble](https://d17oy1vhnax1f7.cloudfront.net/items/3Y3K3V3V3q1g060E3m1R/Image%202017-01-20%20at%201.46.30%20PM.png?v=80cf9442)

*Note: it's also showing the user's password in the console* 🙄

### Solution 
➡️ I just moved this handy method `this.getDefaultFieldValues` to the `componentDidMount` hook, which is not triggered on the server, from the `constructor` which is called on both env.

![no ssr error, react is happy](https://d17oy1vhnax1f7.cloudfront.net/items/0J0l1e0l1S0g3e3B420L/Image%202017-01-20%20at%201.49.40%20PM.png?v=377b6dcc)

So here is my PR to fix that 😄 

We have now 3 calls to `this.setState` on `componentDidMount`, I was thinking of grouping them into one call at the end of the method potentially?
