### PR TITLE
Add missing quote in README code

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ We support the standard [configuration in the account-ui package](http://docs.me
 
 ### Accounts.ui.config(options)
 
-`import { Accounts } from 'meteor/std:accounts-ui`
+`import { Accounts } from 'meteor/std:accounts-ui'`
 
 Configure the behavior of `<Accounts.ui.LoginForm />`
 


### PR DESCRIPTION
The `import` statement in the README was missing a closing quote.