### PR TITLE
Add render with context

### DIFF
--- a/imports/ui/components/LoginForm.jsx
+++ b/imports/ui/components/LoginForm.jsx
@@ -970,7 +970,7 @@ class LoginForm extends Component {
     // XXX Check for backwards compatibility.
     if (Meteor.isClient) {
       const container = document.createElement('div');
-      ReactDOM.render(<Accounts.ui.Field message="test" />, container);
+      ReactDOM.unstable_renderSubtreeIntoContainer(this, <Accounts.ui.Field message="test" />, container);
       if (container.getElementsByClassName('message').length == 0) {
         // Found backwards compatibility issue with 1.3.x
         console.warn(`Implementations of Accounts.ui.Field must render message in v1.2.11.

--- a/imports/ui/components/LoginForm.jsx
+++ b/imports/ui/components/LoginForm.jsx
@@ -1024,10 +1024,12 @@ LoginForm.defaultProps = {
 
 Accounts.ui.LoginForm = LoginForm;
 
-export default createContainer(() => {
+const LoginFormContainer = createContainer(() => {
   // Listen for the user to login/logout and the services list to the user.
   Meteor.subscribe('servicesList');
   return ({
     user: Accounts.user(),
   });
 }, LoginForm);
+Accounts.ui.LoginForm = LoginFormContainer;
+export default LoginFormContainer


### PR DESCRIPTION
for addressing https://github.com/Zetoff/accounts-material-ui/issues/18
In UIs like material ui it needs the context.  This should allow the parent context to be passed down.
