### PR TITLE
Update react-meteor-data to 0.2.15 and remove deprecated createContainer call

### DIFF
--- a/.versions
+++ b/.versions
@@ -43,7 +43,7 @@ ordered-dict@1.0.9
 promise@0.8.9
 random@1.0.10
 rate-limit@1.0.8
-react-meteor-data@0.2.11
+react-meteor-data@0.2.15
 reactive-dict@1.1.9
 reactive-var@1.0.11
 retry@1.0.9
@@ -53,7 +53,7 @@ session@1.1.7
 softwarerero:accounts-t9n@1.3.3
 spacebars@1.0.15
 spacebars-compiler@1.1.2
-std:accounts-ui@1.2.23
+std:accounts-ui@1.3.0
 tmeasday:check-npm-versions@0.3.0
 tracker@1.1.3
 ui@1.0.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+### v1.3
+12-Nov-2017
+
+* Updated LoginForm to be compatible with react-meteor-data 0.2.15 #131.
+* Updated react-meteor-data dependency to 0.2.15.
+
 ### v1.2.23
 15-Jun-2017
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Accounts UI
 
-Current version 1.2.23
+Current version 1.3.0
 
 ## Features
 

--- a/imports/ui/components/LoginForm.jsx
+++ b/imports/ui/components/LoginForm.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import { createContainer } from 'meteor/react-meteor-data';
+import { withTracker } from 'meteor/react-meteor-data';
 import { Accounts } from 'meteor/accounts-base';
 import { T9n } from 'meteor/softwarerero:accounts-t9n';
 import { KEY_PREFIX } from '../../login_session.js';
@@ -1024,10 +1024,10 @@ LoginForm.defaultProps = {
 
 Accounts.ui.LoginForm = LoginForm;
 
-export default createContainer(() => {
+export default withTracker(() => {
   // Listen for the user to login/logout and the services list to the user.
   Meteor.subscribe('servicesList');
   return ({
     user: Accounts.user(),
   });
-}, LoginForm);
+})(LoginForm);

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'std:accounts-ui',
-  version: '1.2.23',
+  version: '1.3.0',
   summary: 'Accounts UI for React in Meteor 1.3+',
   git: 'https://github.com/studiointeract/accounts-ui',
   documentation: 'README.md'
@@ -14,7 +14,7 @@ Package.onUse(function(api) {
   api.use('random');
   api.use('email');
   api.use('session');
-  api.use('react-meteor-data@0.2.11');
+  api.use('react-meteor-data@0.2.15');
   api.use('softwarerero:accounts-t9n');
   api.use('tmeasday:check-npm-versions@0.3.0');
 


### PR DESCRIPTION
As of 0.2.15, the react-meteor-data package has deprecated the `createContainer` function in favor of a new function called `withTracker`. This PR updates the react-meteor-data dependency to the latest version and updates `LoginForm` to be compatible with the new version.

I decided to bump the version to 1.3.0 because the deprecation warning in react-meteor-data 0.2.15 represents a breaking change. Users who update std:accounts-ui to this version will need to update any references to `createContainer` in their project.

Closes:
- #131 
- #130 